### PR TITLE
Pin github actions

### DIFF
--- a/.github/workflows/update-gardenlogin.yaml
+++ b/.github/workflows/update-gardenlogin.yaml
@@ -8,7 +8,7 @@ jobs:
   update_gardenlogin_in_homebrew_tap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - name: Build the binary-files
         id: build_binary_files
         run: |
@@ -17,7 +17,7 @@ jobs:
           make build
           echo ::set-output name=latest_release_filtered_tag::${GITHUB_REF##*/}
       - name: Upload binaries to release
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@ec6d3263266dc57eb6645b5f75e827987f7c217d # pin@v2.0
         with:
           files: 'bin/darwin-amd64/gardenlogin_darwin_amd64;bin/linux-amd64/gardenlogin_linux_amd64'
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions

> **Pin actions to a full length commit SHA**
> 
> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
