### PR TITLE
Add help make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,31 +11,45 @@ endif
 
 export LD_FLAGS=$(shell ./hack/get-build-ld-flags.sh)
 
-# Run tests
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-13s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development
+
 .PHONY: test
-test: generate lint
+test: generate lint ## Run tests.
 	go test ./... -coverprofile cover.out
 
-# Run golangci-lint against code
 .PHONY: lint
-lint:
+lint: ## Run golangci-lint against code.
 	@./hack/golangci-lint.sh
 
-.PHONY: generate
-generate:
-	go generate ./...
+##@ Build
 
 .PHONY: build
-build: build-darwin build-linux build-windows
+build: build-darwin build-linux build-windows  ## Build gardenlogin binary for darwin, linux and windows.
 
 .PHONY: build-linux
-build-linux:
+build-linux: ## Build gardenlogin binary for linux.
 	@./hack/build-linux-amd64.sh
 
 .PHONY: build-darwin
-build-darwin:
+build-darwin: ## Build gardenlogin binary for darwin.
 	@./hack/build-darwin-amd64.sh
 
 .PHONY: build-windows
-build-windows:
+build-windows: ## Build gardenlogin binary for windows.
 	@./hack/build-windows-amd64.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a help make target to print out all available targets with their short description
Also, the currently unused `generate` target was removed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
