### PR TITLE
[master] Fix darwin-arm64 release asset upload

### DIFF
--- a/.github/workflows/update-gardenlogin.yaml
+++ b/.github/workflows/update-gardenlogin.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Upload binaries to release
         uses: AButler/upload-release-assets@ec6d3263266dc57eb6645b5f75e827987f7c217d # pin@v2.0
         with:
-          files: 'bin/darwin-amd64/gardenlogin_darwin_amd64;bin/linux-amd64/gardenlogin_linux_amd64;bin/windows-amd64/gardenlogin_windows_amd64.exe'
+          files: 'bin/darwin-amd64/gardenlogin_darwin_amd64;bin/darwin-arm64/gardenlogin_darwin_arm64;bin/linux-amd64/gardenlogin_linux_amd64;bin/windows-amd64/gardenlogin_windows_amd64.exe'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           release-tag: ${{ steps.build_binary_files.outputs.latest_release_filtered_tag }}
       - name: Get token for gardener-github-pkg-mngr app


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the gardenlogin darwin-arm64 release asset will be uploaded on the next release

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
