### PR TITLE
Configuration changes - Fallback to `gardenctl-v2` config and property name changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,18 @@ ln -s /usr/local/bin/gardenlogin /usr/local/bin/kubectl-gardenlogin
 ```
 
 ## Configure Gardenlogin
-`gardenlogin` requires a configuration file. The default location is in `~/.garden/gardenlogin.yaml`.
-### Config Path Overwrite:
+`gardenlogin` requires a configuration file. The default location is in `~/.garden/gardenlogin.yaml`. 
+
+If no configuration file is found, it falls back to the `gardenctl-v2` configuration file (`~/.garden/gardenctl-v2.yaml`) which shares the same configuration properties.
+
+### Example Config
+```yaml
+gardens:
+- identity: landscape-dev # Unique identity of the garden cluster. See cluster-identity ConfigMap in kube-system namespace of the garden cluster
+  kubeconfig: ~/path/to/garden-cluster/kubeconfig.yaml
+```
+
+### Config Path Overwrite
 - The `gardenlogin` config path can be overwritten with the environment variable `GL_HOME`.
 - The `gardenlogin` config name can be overwritten with the environment variable `GL_CONFIG_NAME`.
 
@@ -60,13 +70,6 @@ ln -s /usr/local/bin/gardenlogin /usr/local/bin/kubectl-gardenlogin
 export GL_HOME=/alternate/garden/config/dir
 export GL_CONFIG_NAME=myconfig # without extension!
 # config is expected to be under /alternate/garden/config/dir/myconfig.yaml
-```
-
-### Example Config:
-```yaml
-gardenClusters:
-- clusterIdentity: landscape-dev # Unique identifier of the garden cluster. See cluster-identity ConfigMap in kube-system namespace of the garden cluster
-  kubeconfig: ~/path/to/garden-cluster/kubeconfig.yaml
 ```
 
 ## Usage

--- a/cmd/get_client_certificate.go
+++ b/cmd/get_client_certificate.go
@@ -107,9 +107,7 @@ func init() {
 		klog.Errorf("could not determine home directory %v", err)
 	}
 
-	f := &util.FactoryImpl{
-		HomeDirectory: dir,
-	}
+	f := util.NewFactory(dir)
 
 	getClientCertificateCmd = NewCmdGetClientCertificate(f, ioStreams)
 

--- a/cmd/get_client_certificate.go
+++ b/cmd/get_client_certificate.go
@@ -52,7 +52,7 @@ var (
 type ExecPluginConfig struct {
 	// ShootRef references the shoot cluster
 	ShootRef ShootRef `json:"shootRef"`
-	// GardenClusterIdentity is the cluster identifier of the garden cluster.
+	// GardenClusterIdentity is the cluster identity of the garden cluster.
 	// See cluster-identity ConfigMap in kube-system namespace of the garden cluster
 	GardenClusterIdentity string `json:"gardenClusterIdentity"`
 }
@@ -87,7 +87,7 @@ type GetClientCertificateOptions struct {
 	// ShootRef references the shoot cluster for which the client certificate credentials should be obtained
 	ShootRef ShootRef
 
-	// GardenClusterIdentity is the cluster identifier of the garden cluster.
+	// GardenClusterIdentity is the cluster identity of the garden cluster.
 	// See cluster-identity ConfigMap in kube-system namespace of the garden cluster
 	GardenClusterIdentity string
 
@@ -152,7 +152,7 @@ func NewCmdGetClientCertificate(f util.Factory, ioStreams genericclioptions.IOSt
 
 	cmd.Flags().StringVar(&o.ShootRef.Name, flagName, "", "Name of the shoot cluster")
 	cmd.Flags().StringVar(&o.ShootRef.Namespace, flagNamespace, "", "Namespace of the shoot cluster")
-	cmd.Flags().StringVar(&o.GardenClusterIdentity, flagGardenClusterIdentity, "", "Cluster identifier of the garden cluster")
+	cmd.Flags().StringVar(&o.GardenClusterIdentity, flagGardenClusterIdentity, "", "Cluster identity of the garden cluster")
 	cmd.Flags().StringVar(&o.CertificateCacheDir, flagCertificateCacheDir, filepath.Join(f.HomeDir(), ".kube", "cache", "gardenlogin"), "Directory of the certificate cache")
 	cmd.Flags().Int64Var(&o.AdminKubeconfigExpirationSeconds, flagExpirationSeconds, 900, "Validity duration of the requested credential")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,7 +90,7 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err != nil {
+	if err := readInConfig(); err != nil {
 		klog.Errorf("failed to read config file: %v", err)
 	}
 
@@ -124,4 +124,56 @@ func addKlogFlags(fs *pflag.FlagSet) {
 	local.VisitAll(func(fl *flag.Flag) {
 		fs.AddGoFlag(fl)
 	})
+}
+
+func readInConfig() error {
+	origErr := viper.ReadInConfig()
+	if origErr == nil {
+		return nil
+	}
+
+	if _, ok := origErr.(viper.ConfigFileNotFoundError); ok { // fallback to gardenctl-v2 config
+		addGardenctlV2Config()
+
+		err := viper.ReadInConfig()
+		if err == nil {
+			return nil
+		}
+
+		if _, ok := origErr.(viper.ConfigFileNotFoundError); ok {
+			return origErr
+		}
+
+		return fmt.Errorf("failed to fallback to gardenctl-v2 config file: %w", err)
+	}
+	return origErr
+}
+
+func addGardenctlV2Config() {
+	const (
+		envPrefix        = "GCTL"
+		envGardenHomeDir = envPrefix + "_HOME"
+		envConfigName    = envPrefix + "_CONFIG_NAME"
+
+		gardenHomeFolder = ".garden"
+		configName       = "gardenctl-v2"
+	)
+
+	// Find home directory.
+	home, err := homedir.Dir()
+	cobra.CheckErr(err)
+
+	configPath := filepath.Join(home, gardenHomeFolder)
+
+	// Search config in $HOME/.garden or in path provided with the env variable GCTL_HOME with name ".garden-login" (without extension) or name from env variable GCTL_CONFIG_NAME.
+	envHomeDir, err := homedir.Expand(os.Getenv(envGardenHomeDir))
+	cobra.CheckErr(err)
+
+	viper.AddConfigPath(envHomeDir)
+	viper.AddConfigPath(configPath)
+	if os.Getenv(envConfigName) != "" {
+		viper.SetConfigName(os.Getenv(envConfigName))
+	} else {
+		viper.SetConfigName(configName)
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,7 +73,7 @@ func initConfig() {
 
 		configPath := filepath.Join(home, gardenHomeFolder)
 
-		// Search config in $HOME/.garden or in path provided with the env variable GL_HOME with name ".gardenlogin" (without extension) or name from env variable GL_CONFIG_NAME.
+		// Search config in ~/.garden or in path provided with the env variable GL_HOME with name "gardenlogin" (without extension) or name from env variable GL_CONFIG_NAME.
 		envHomeDir, err := homedir.Expand(os.Getenv(envGardenHomeDir))
 		cobra.CheckErr(err)
 
@@ -167,7 +167,7 @@ func addGardenctlV2Config() {
 
 	configPath := filepath.Join(home, gardenHomeFolder)
 
-	// Search config in $HOME/.garden or in path provided with the env variable GCTL_HOME with name ".garden-login" (without extension) or name from env variable GCTL_CONFIG_NAME.
+	// Search config in ~/.garden or in path provided with the env variable GCTL_HOME with name "gardenctl-v2" (without extension) or name from env variable GCTL_CONFIG_NAME.
 	envHomeDir, err := homedir.Expand(os.Getenv(envGardenHomeDir))
 	cobra.CheckErr(err)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,7 @@ func initConfig() {
 
 		viper.AddConfigPath(envHomeDir)
 		viper.AddConfigPath(configPath)
+
 		if os.Getenv(envConfigName) != "" {
 			viper.SetConfigName(os.Getenv(envConfigName))
 		} else {
@@ -146,6 +147,7 @@ func readInConfig() error {
 
 		return fmt.Errorf("failed to fallback to gardenctl-v2 config file: %w", err)
 	}
+
 	return origErr
 }
 
@@ -171,6 +173,7 @@ func addGardenctlV2Config() {
 
 	viper.AddConfigPath(envHomeDir)
 	viper.AddConfigPath(configPath)
+
 	if os.Getenv(envConfigName) != "" {
 		viper.SetConfigName(os.Getenv(envConfigName))
 	} else {

--- a/internal/certificatecache/store/store.go
+++ b/internal/certificatecache/store/store.go
@@ -31,7 +31,7 @@ type entity struct {
 }
 
 // Store provides access to the certificate cache on the local filesystem.
-// Filename of a certificate cache is sha256 digest of the shoot server, shoot name, shoot namespace and garden cluster identifier
+// Filename of a certificate cache is sha256 digest of the shoot server, shoot name, shoot namespace and garden cluster identity
 type Store struct {
 	// Dir is the backing directory of the store credentials
 	Dir string

--- a/internal/certificatecache/types.go
+++ b/internal/certificatecache/types.go
@@ -14,7 +14,7 @@ type Key struct {
 	ShootName string
 	// ShootNamespace is the namespace of the shoot in the garden cluster
 	ShootNamespace string
-	// GardenClusterIdentity is the cluster identifier of the garden cluster.
+	// GardenClusterIdentity is the cluster identity of the garden cluster.
 	// See cluster-identity ConfigMap in kube-system namespace of the garden cluster
 	GardenClusterIdentity string
 }

--- a/internal/cmd/util/config.go
+++ b/internal/cmd/util/config.go
@@ -6,29 +6,62 @@ SPDX-License-Identifier: Apache-2.0
 
 package util
 
-import "fmt"
+import (
+	"fmt"
 
-// GardenloginConfig holds the gardenlogin config
-type GardenloginConfig struct {
-	GardenClusters []GardenClusterConfig
+	"k8s.io/klog/v2"
+)
+
+// Config holds the gardenlogin config
+type Config struct {
+	// Gardens is a list of known Garden clusters
+	Gardens []Garden `yaml:"gardens"`
+
+	// GardenClusters is a list of known Garden clusters
+	// Deprecated: use Gardens instead
+	GardenClusters []GardenClusterConfig `yaml:"gardenClusters"`
+}
+
+// Garden holds the config of a garden cluster
+type Garden struct {
+	// Identity is the cluster identity of the garden cluster.
+	// See cluster-identity ConfigMap in kube-system namespace of the garden cluster
+	Identity string `yaml:"identity"`
+
+	// Kubeconfig holds the path for the kubeconfig of the garden cluster
+	Kubeconfig string `yaml:"kubeconfig"`
 }
 
 // GardenClusterConfig holds the config of a garden cluster
+// Deprecated: use Garden instead
 type GardenClusterConfig struct {
 	// ClusterIdentity is the cluster identifier of the garden cluster.
-	// See cluster-identity ConfigMap in kube-system namespace of the garden cluster
-	ClusterIdentity string
+	// Deprecated: use Garden.Identity instead
+	ClusterIdentity string `yaml:"clusterIdentity"`
+
 	// Kubeconfig holds the path for the kubeconfig of the garden cluster
-	Kubeconfig string
+	// Deprecated: use Garden.Kubeconfig instead
+	Kubeconfig string `yaml:"kubeconfig"`
 }
 
-// GetClusterConfigForClusterIdentity returns the garden cluster for a given cluster identity.
+// FindGarden returns the garden cluster config for a given cluster identity.
 // It returns an error if no matching garden cluster with the given cluster identity was found.
-func (c *GardenloginConfig) GetClusterConfigForClusterIdentity(clusterIdentity string) (*GardenClusterConfig, error) {
+func (c *Config) FindGarden(clusterIdentity string) (*Garden, error) {
+	for _, cluster := range c.Gardens {
+		if cluster.Identity == clusterIdentity {
+			return &cluster, nil
+		}
+	}
+
+	// fallback logic with deprecated properties
 	gardenClusters := c.GardenClusters
 	for _, cluster := range gardenClusters {
 		if cluster.ClusterIdentity == clusterIdentity {
-			return &cluster, nil
+			klog.Warningln("Your are using deprecated config properties for gardenlogin. Please update your config file as these properties will not be supported in future versions. \"gardenClusters\" was renamed to \"gardens\", \"clusterIdentity\" was renamed to \"identity\".\n")
+			return &Garden{
+				Identity:   cluster.ClusterIdentity,
+				Kubeconfig: cluster.Kubeconfig,
+			}, nil
 		}
 	}
 

--- a/internal/cmd/util/config.go
+++ b/internal/cmd/util/config.go
@@ -58,6 +58,7 @@ func (c *Config) FindGarden(clusterIdentity string) (*Garden, error) {
 	for _, cluster := range gardenClusters {
 		if cluster.ClusterIdentity == clusterIdentity {
 			klog.Warningln("Your are using deprecated config properties for gardenlogin. Please update your config file as these properties will not be supported in future versions. \"gardenClusters\" was renamed to \"gardens\", \"clusterIdentity\" was renamed to \"identity\".\n")
+
 			return &Garden{
 				Identity:   cluster.ClusterIdentity,
 				Kubeconfig: cluster.Kubeconfig,

--- a/internal/cmd/util/factory.go
+++ b/internal/cmd/util/factory.go
@@ -45,18 +45,18 @@ func (f *FactoryImpl) Clock() Clock {
 
 // RESTClient returns the rest client for the garden cluster, identified by the garden cluster identity
 func (f *FactoryImpl) RESTClient(gardenClusterIdentity string) (rest.Interface, error) {
-	config := &GardenloginConfig{}
+	config := &Config{}
 	if err := viper.Unmarshal(config); err != nil {
 		return nil, err
 	}
 
-	gardenClusterConfig, err := config.GetClusterConfigForClusterIdentity(gardenClusterIdentity)
+	garden, err := config.FindGarden(gardenClusterIdentity)
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO allow to select context
-	kubeconfig, err := homedir.Expand(gardenClusterConfig.Kubeconfig)
+	kubeconfig, err := homedir.Expand(garden.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. ⚠️ the configuration properties have changed to align with `gardenctl-v2`. The following properties were marked deprecated. The local config file should be adapted accordingly:
- `gardenClusters` was renamed to `gardens`
- `clusterIdentity` was renamed to `identity`
2. If no configuration file is found (`~/.garden/gardenlogin.yaml`), it falls back to the `gardenctl-v2` configuration file (`~/.garden/gardenctl-v2.yaml`) which shares the same configuration properties.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
⚠️ the configuration properties have changed to align with `gardenctl-v2`. Please rename your configuration properties accordingly as they may not be supported with future `gardenlogin` releases:
- `gardenClusters` was renamed to `gardens`
- `clusterIdentity` was renamed to `identity`
```

```feature user
If no configuration file is found, it falls back to the `gardenctl-v2` configuration file (`~/.garden/gardenctl-v2.yaml`) which shares the same configuration properties
```
