### PR TITLE
Use username instead of context name

### DIFF
--- a/cmd/get_client_certificate.go
+++ b/cmd/get_client_certificate.go
@@ -419,9 +419,9 @@ func clusterNameFromConfigForCluster(config api.Config, cluster *clientauthv1bet
 }
 
 func userNameFromConfigForClusterName(config api.Config, clusterName string) (string, error) {
-	for name, c := range config.Contexts {
+	for _, c := range config.Contexts {
 		if clusterName == c.Cluster {
-			return name, nil
+			return c.AuthInfo, nil
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed an issue where instead of the user the context name was returned for a given cluster name. This resulted in the error message `Error: failed to get ExecCredential: could not find matching auth info from shoot kubeconfig for given cluster: no matching user config found for user name garden-myproject--mycluster-internal`.

This issue usually occurred when switching from the default `*-external` context (`garden-myproject--mycluster-external`) to the internal context (`garden-myproject--mycluster-internal`). 
The reason why it worked (by chance) for the default context is, that the user is named as the context (`garden-myproject--mycluster-external`). 

See example kubeconfig that is returned by the `shoots/adminkubeconfig` subresource
```yaml
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: LS0t...
    server: https://api.mycluster.myproject.gardener.example.com
  name: garden-myproject--mycluster-external
- cluster:
    certificate-authority-data: LS0t...
    server: https://api.ls-gardener-test.core.internal.dev.k8s.ondemand.com
  name: garden-myproject--mycluster-internal
contexts:
- context:
    cluster: garden-myproject--mycluster-external
    user: garden-myproject--mycluster-external
  name: garden-myproject--mycluster-external
- context:
    cluster: garden-myproject--mycluster-internal
    user: garden-myproject--mycluster-external
  name: garden-myproject--mycluster-internal
current-context: garden-myproject--mycluster-external
kind: Config
preferences: {}
users:
- name: garden-myproject--mycluster-external
  user:
    client-certificate-data: LS0t...
    client-key-data: LS0t...
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue when switching to the `*-internal` context (`no matching user config found for user name garden-myproject--mycluster-internal`)
```
