### PR TITLE
Use only server to find matching cluster

### DIFF
--- a/cmd/get_client_certificate.go
+++ b/cmd/get_client_certificate.go
@@ -24,7 +24,6 @@ import (
 	gardenscheme "github.com/gardener/gardener/pkg/client/core/clientset/versioned/scheme"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	clientauthv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
@@ -409,13 +408,12 @@ func clusterNameFromConfigForCluster(config api.Config, cluster *clientauthv1bet
 	}
 
 	for name, c := range config.Clusters {
-		if cluster.Server == c.Server &&
-			apiequality.Semantic.DeepEqual(cluster.CertificateAuthorityData, c.CertificateAuthorityData) {
+		if cluster.Server == c.Server {
 			return name, nil
 		}
 	}
 
-	return "", fmt.Errorf("no matching cluster found for server %s and certificate-authority-data", cluster.Server)
+	return "", fmt.Errorf("no matching cluster found for server %s", cluster.Server)
 }
 
 func userNameFromConfigForClusterName(config api.Config, clusterName string) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When trying to find a matching cluster from the kubeconfig returned by the `shoots/adminkubeconfig` endpoint, the ca is not considered anymore. The additional check for a matching ca caused issues when rotating the clusters CA. The check is not necessarily needed, as it is assumed that the `shoots/adminkubeconfig` endpoint returns a cluster list with unique `cluster.server` fields.

**Which issue(s) this PR fixes**:
Fixes #28 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue where `gardenlogin` would report that no matching cluster could be found for server and certificate-authority-data in case the Shoot cluster CA is being rotated
```
