### PR TITLE
Bump golang from 1.18 to 1.19.5

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,11 +9,11 @@ gardenlogin:
         inject_effective_version: true
     steps:
       check:
-        image: 'golang:1.18'
+        image: 'golang:1.19.5'
       test:
-        image: 'golang:1.18'
+        image: 'golang:1.19.5'
       build:
-        image: 'golang:1.18'
+        image: 'golang:1.19.5'
         output_dir: 'binary'
         timeout: '5m'
 

--- a/.github/workflows/update-gardenlogin.yaml
+++ b/.github/workflows/update-gardenlogin.yaml
@@ -8,10 +8,10 @@ jobs:
   update_gardenlogin_in_homebrew_tap_and_chocolatey_packages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # pin@v2.4.0
-      - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # pin@v2.1.4
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # pin@v3.5.0
         with:
-          go-version: '^1.17'
+          go-version: '1.19.5'
       - name: Build the binary-files
         id: build_binary_files
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardenlogin
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gardener/gardener v1.50.1


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps golang from 1.18 to 1.19.5

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
