### PR TITLE
Support v1 ExecCredential

### DIFF
--- a/.gimps.yaml
+++ b/.gimps.yaml
@@ -23,6 +23,10 @@ aliasRules:
     expr: '^k8s.io/client-go/tools/([a-z0-9-]+)/api/(latest)$'
     alias: '$1$2'
 
+  - name: client-go-apis
+    expr: '^k8s.io/client-go/pkg/apis/([a-z0-9-]+)/(v[a-z0-9-]+)$'
+    alias: '$1$2'
+
   - name: k8s-api
     expr: '^k8s.io/api/([a-z0-9-]+)/(v[a-z0-9-]+)$'
     alias: '$1$2'

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: test
-test: fmt lint ## Run tests.
-	@./hack/test-integration.sh
+test: fmt lint go-test ## Run tests.
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
@@ -41,6 +40,10 @@ fmt: ## Run go fmt against code.
 .PHONY: lint
 lint: ## Run golangci-lint against code.
 	@./hack/golangci-lint.sh
+
+.PHONY: go-test
+go-test: ## Run go tests.
+	@./hack/test-integration.sh
 
 ##@ Build
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ users:
 - name: shoot--myproject--mycluster
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1
       provideClusterInfo: true
       command: kubectl
       args:

--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -9,9 +9,29 @@ package cmd_test
 import (
 	"testing"
 
+	"github.com/gardener/gardener/pkg/apis/authentication"
+	authenticationv1alpha1 "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
+	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
+
+	"github.com/gardener/gardenlogin/internal/clientauthentication"
 )
+
+func init() {
+	scheme := clientgoscheme.Scheme
+
+	utilruntime.Must(authenticationv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(authentication.AddToScheme(scheme))
+
+	utilruntime.Must(clientauthenticationv1beta1.AddToScheme(scheme))
+	utilruntime.Must(clientauthenticationv1.AddToScheme(scheme))
+
+	utilruntime.Must(clientauthentication.AddConversionFuncs(scheme))
+}
 
 func TestCmd(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/cmd/get_client_certificate.go
+++ b/cmd/get_client_certificate.go
@@ -21,6 +21,9 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
 	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/auth/exec"
@@ -73,6 +76,9 @@ type GetClientCertificateOptions struct {
 	// Clock provides the current time
 	Clock util.Clock
 
+	// GroupVersion determines the version for the output ExecCredential
+	GroupVersion schema.GroupVersion
+
 	// Common user flags
 
 	// ShootCluster holds the data of the shoot kubernetes cluster.
@@ -81,7 +87,7 @@ type GetClientCertificateOptions struct {
 	// If nil the cluster of the current context from the kubeconfig returned by the "shoots/adminkubeconfig" subresource is used.
 	// TODO once we drop support for kubectl versions older than v1.20.0, this field should be made required
 	// +optional
-	ShootCluster *clientauthenticationv1beta1.Cluster
+	ShootCluster *clientauthenticationv1.Cluster
 	// ShootRef references the shoot cluster for which the client certificate credentials should be obtained
 	ShootRef ShootRef
 
@@ -164,20 +170,27 @@ func (o *GetClientCertificateOptions) Complete(f util.Factory, cmd *cobra.Comman
 			return err
 		}
 
-		v1beta1ExecCredential, ok := obj.(*clientauthenticationv1beta1.ExecCredential)
+		o.GroupVersion = obj.GetObjectKind().GroupVersionKind().GroupVersion()
+
+		obj, err = scheme.Scheme.ConvertToVersion(obj, clientauthenticationv1.SchemeGroupVersion)
+		if err != nil {
+			return fmt.Errorf("cannot convert to %s: %w", clientauthenticationv1.SchemeGroupVersion, err)
+		}
+
+		v1ExecCredential, ok := obj.(*clientauthenticationv1.ExecCredential)
 		if !ok {
-			return fmt.Errorf("cannot convert to ExecCredential: %w", err)
+			return errors.New("obj is not of type clientauthenticationv1.ExecCredential")
 		}
 
 		var extension ExecPluginConfig
 
-		if v1beta1ExecCredential.Spec.Cluster.Config.Raw != nil {
-			if err := json.Unmarshal(v1beta1ExecCredential.Spec.Cluster.Config.Raw, &extension); err != nil {
+		if v1ExecCredential.Spec.Cluster.Config.Raw != nil {
+			if err := json.Unmarshal(v1ExecCredential.Spec.Cluster.Config.Raw, &extension); err != nil {
 				return err
 			}
 		}
 
-		o.ShootCluster = v1beta1ExecCredential.Spec.Cluster
+		o.ShootCluster = v1ExecCredential.Spec.Cluster
 
 		if o.GardenClusterIdentity == "" {
 			o.GardenClusterIdentity = extension.GardenClusterIdentity
@@ -190,6 +203,9 @@ func (o *GetClientCertificateOptions) Complete(f util.Factory, cmd *cobra.Comman
 		if o.ShootRef.Namespace == "" {
 			o.ShootRef.Namespace = extension.ShootRef.Namespace
 		}
+	} else {
+		// fallback to v1beta1 for kubectl versions < v1.20.0
+		o.GroupVersion = clientauthenticationv1beta1.SchemeGroupVersion
 	}
 
 	o.CertificateCacheStore = f.CertificateStore(o.CertificateCacheDir)
@@ -255,20 +271,25 @@ func (o *GetClientCertificateOptions) RunGetClientCertificate(ctx context.Contex
 		klog.V(4).Infof("could not find a cached certificate: %v", err)
 	}
 
-	v1beta1ExecCredential, err := o.getExecCredential(ctx, certificateCacheKey, cachedCertificateSet)
+	v1ExecCredential, err := o.getExecCredential(ctx, certificateCacheKey, cachedCertificateSet)
 	if err != nil {
 		return fmt.Errorf("failed to get ExecCredential: %w", err)
 	}
 
+	execCredential, err := scheme.Scheme.ConvertToVersion(v1ExecCredential, o.GroupVersion)
+	if err != nil {
+		return fmt.Errorf("cannot convert to %s: %w", o.GroupVersion, err)
+	}
+
 	e := json.NewEncoder(o.IOStreams.Out)
-	if err := e.Encode(v1beta1ExecCredential); err != nil {
+	if err := e.Encode(execCredential); err != nil {
 		return fmt.Errorf("could not write the ExecCredential: %w", err)
 	}
 
 	return nil
 }
 
-func (o *GetClientCertificateOptions) getExecCredential(ctx context.Context, certificateCacheKey certificatecache.Key, cachedCertificateSet *certificatecache.CertificateSet) (*clientauthenticationv1beta1.ExecCredential, error) {
+func (o *GetClientCertificateOptions) getExecCredential(ctx context.Context, certificateCacheKey certificatecache.Key, cachedCertificateSet *certificatecache.CertificateSet) (*clientauthenticationv1.ExecCredential, error) {
 	if cachedCertificateSet != nil {
 		certPem, _ := pem.Decode(cachedCertificateSet.ClientCertificateData)
 		if certPem == nil {
@@ -287,12 +308,12 @@ func (o *GetClientCertificateOptions) getExecCredential(ctx context.Context, cer
 		if validNotBefore && validNotAfter {
 			klog.V(4).Info("valid certificate in cache")
 
-			return &clientauthenticationv1beta1.ExecCredential{
+			return &clientauthenticationv1.ExecCredential{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: clientauthenticationv1beta1.SchemeGroupVersion.String(),
+					APIVersion: clientauthenticationv1.SchemeGroupVersion.String(),
 					Kind:       "ExecCredential",
 				},
-				Status: &clientauthenticationv1beta1.ExecCredentialStatus{
+				Status: &clientauthenticationv1.ExecCredentialStatus{
 					ExpirationTimestamp:   &metav1.Time{Time: certificate.NotAfter},
 					ClientCertificateData: string(cachedCertificateSet.ClientCertificateData),
 					ClientKeyData:         string(cachedCertificateSet.ClientKeyData),
@@ -338,12 +359,12 @@ func (o *GetClientCertificateOptions) getExecCredential(ctx context.Context, cer
 		return nil, err
 	}
 
-	return &clientauthenticationv1beta1.ExecCredential{
+	return &clientauthenticationv1.ExecCredential{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: clientauthenticationv1beta1.SchemeGroupVersion.String(),
+			APIVersion: clientauthenticationv1.SchemeGroupVersion.String(),
 			Kind:       "ExecCredential",
 		},
-		Status: &clientauthenticationv1beta1.ExecCredentialStatus{
+		Status: &clientauthenticationv1.ExecCredentialStatus{
 			ExpirationTimestamp:   &adminKubeconfigRequest.Status.ExpirationTimestamp,
 			ClientCertificateData: string(certificateSet.ClientCertificateData),
 			ClientKeyData:         string(certificateSet.ClientKeyData),
@@ -370,7 +391,7 @@ func createAdminKubeconfigRequest(ctx context.Context, client rest.Interface, na
 	return result, nil
 }
 
-func authInfoFromKubeconfigForCluster(kubeconfig []byte, cluster *clientauthenticationv1beta1.Cluster) (*api.AuthInfo, error) {
+func authInfoFromKubeconfigForCluster(kubeconfig []byte, cluster *clientauthenticationv1.Cluster) (*api.AuthInfo, error) {
 	shootClientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
 	if err != nil {
 		return nil, err
@@ -394,7 +415,7 @@ func authInfoFromKubeconfigForCluster(kubeconfig []byte, cluster *clientauthenti
 	return authInfoFromConfigForUserName(config, userName)
 }
 
-func clusterNameFromConfigForCluster(config api.Config, cluster *clientauthenticationv1beta1.Cluster) (string, error) {
+func clusterNameFromConfigForCluster(config api.Config, cluster *clientauthenticationv1.Cluster) (string, error) {
 	if cluster == nil {
 		// fallback to cluster from current context (to support kubectl versions older v1.20.0)
 		context := config.Contexts[config.CurrentContext]

--- a/cmd/get_client_certificate.go
+++ b/cmd/get_client_certificate.go
@@ -164,20 +164,20 @@ func (o *GetClientCertificateOptions) Complete(f util.Factory, cmd *cobra.Comman
 			return err
 		}
 
-		cred, ok := obj.(*clientauthenticationv1beta1.ExecCredential)
+		v1beta1ExecCredential, ok := obj.(*clientauthenticationv1beta1.ExecCredential)
 		if !ok {
 			return fmt.Errorf("cannot convert to ExecCredential: %w", err)
 		}
 
 		var extension ExecPluginConfig
 
-		if cred.Spec.Cluster.Config.Raw != nil {
-			if err := json.Unmarshal(cred.Spec.Cluster.Config.Raw, &extension); err != nil {
+		if v1beta1ExecCredential.Spec.Cluster.Config.Raw != nil {
+			if err := json.Unmarshal(v1beta1ExecCredential.Spec.Cluster.Config.Raw, &extension); err != nil {
 				return err
 			}
 		}
 
-		o.ShootCluster = cred.Spec.Cluster
+		o.ShootCluster = v1beta1ExecCredential.Spec.Cluster
 
 		if o.GardenClusterIdentity == "" {
 			o.GardenClusterIdentity = extension.GardenClusterIdentity
@@ -255,13 +255,13 @@ func (o *GetClientCertificateOptions) RunGetClientCertificate(ctx context.Contex
 		klog.V(4).Infof("could not find a cached certificate: %v", err)
 	}
 
-	ec, err := o.getExecCredential(ctx, certificateCacheKey, cachedCertificateSet)
+	v1beta1ExecCredential, err := o.getExecCredential(ctx, certificateCacheKey, cachedCertificateSet)
 	if err != nil {
 		return fmt.Errorf("failed to get ExecCredential: %w", err)
 	}
 
 	e := json.NewEncoder(o.IOStreams.Out)
-	if err := e.Encode(ec); err != nil {
+	if err := e.Encode(v1beta1ExecCredential); err != nil {
 		return fmt.Errorf("could not write the ExecCredential: %w", err)
 	}
 

--- a/cmd/get_client_certificate_test.go
+++ b/cmd/get_client_certificate_test.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/gardener/gardener/pkg/apis/authentication"
 	authenticationv1alpha1 "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -37,7 +36,6 @@ import (
 	c "github.com/gardener/gardenlogin/cmd"
 	"github.com/gardener/gardenlogin/internal/certificatecache"
 	"github.com/gardener/gardenlogin/internal/certificatecache/store"
-	"github.com/gardener/gardenlogin/internal/clientauthentication"
 	"github.com/gardener/gardenlogin/internal/cmd/util"
 )
 
@@ -60,17 +58,7 @@ var _ = Describe("GetClientCertificate", func() {
 	)
 
 	BeforeEach(func() {
-		scheme := clientgoscheme.Scheme
-
-		Expect(authenticationv1alpha1.AddToScheme(scheme)).To(Succeed())
-		Expect(authentication.AddToScheme(scheme)).To(Succeed())
-
-		Expect(clientauthenticationv1beta1.AddToScheme(scheme)).To(Succeed())
-		Expect(clientauthenticationv1.AddToScheme(scheme)).To(Succeed())
-
-		Expect(clientauthentication.AddConversionFuncs(scheme)).To(Succeed())
-
-		codecs = serializer.NewCodecFactory(scheme)
+		codecs = serializer.NewCodecFactory(clientgoscheme.Scheme)
 		codec = codecs.LegacyCodec(authenticationv1alpha1.SchemeGroupVersion)
 
 		ioStreams, _, out, errOut = util.NewTestIOStreams()

--- a/cmd/get_client_certificate_test.go
+++ b/cmd/get_client_certificate_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
+	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/utils/clock/testing"
@@ -52,7 +52,7 @@ var _ = Describe("GetClientCertificate", func() {
 		out       *util.SafeBytesBuffer
 
 		shootCaData []byte
-		ec          v1beta1.ExecCredential
+		ec          clientauthenticationv1beta1.ExecCredential
 	)
 
 	BeforeEach(func() {
@@ -102,13 +102,13 @@ users:
 		epcRaw, err := json.Marshal(epc)
 		Expect(err).ToNot(HaveOccurred())
 
-		ec = v1beta1.ExecCredential{
+		ec = clientauthenticationv1beta1.ExecCredential{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ExecCredential",
-				APIVersion: v1beta1.SchemeGroupVersion.String(),
+				APIVersion: clientauthenticationv1beta1.SchemeGroupVersion.String(),
 			},
-			Spec: v1beta1.ExecCredentialSpec{
-				Cluster: &v1beta1.Cluster{
+			Spec: clientauthenticationv1beta1.ExecCredentialSpec{
+				Cluster: &clientauthenticationv1beta1.Cluster{
 					Server:                   "https://api.mycluster.myproject.foo",
 					CertificateAuthorityData: shootCaData,
 					Config: runtime.RawExtension{
@@ -128,7 +128,7 @@ users:
 		BeforeEach(func() {
 			// valid GetClientCertificateOptions
 			o = c.GetClientCertificateOptions{
-				ShootCluster: &v1beta1.Cluster{
+				ShootCluster: &clientauthenticationv1beta1.Cluster{
 					Server:                   "foo",
 					CertificateAuthorityData: []byte("foo"),
 				},

--- a/example/01-kubeconfig.yaml
+++ b/example/01-kubeconfig.yaml
@@ -27,7 +27,7 @@ users:
 - name: shoot--myproject--mycluster
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1
       provideClusterInfo: true
       command: kubectl
       args:

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -17,7 +17,7 @@ else
 fi
 
 # Install golangci-lint (linting tool)
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.2
 
 echo "> Lint gardenlogin"
 

--- a/internal/clientauthentication/clientauthentication_suite_test.go
+++ b/internal/clientauthentication/clientauthentication_suite_test.go
@@ -1,0 +1,19 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package clientauthentication_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Clientauthentication Suite")
+}

--- a/internal/clientauthentication/clientauthentication_suite_test.go
+++ b/internal/clientauthentication/clientauthentication_suite_test.go
@@ -11,7 +11,22 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
+	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
+
+	"github.com/gardener/gardenlogin/internal/clientauthentication"
 )
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientauthenticationv1beta1.AddToScheme(scheme))
+	utilruntime.Must(clientauthenticationv1.AddToScheme(scheme))
+
+	utilruntime.Must(clientauthentication.AddConversionFuncs(scheme))
+}
 
 func TestCmd(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/clientauthentication/conversion.go
+++ b/internal/clientauthentication/conversion.go
@@ -1,0 +1,53 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package clientauthentication
+
+import (
+	"errors"
+
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/pkg/apis/clientauthentication"
+	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
+	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
+)
+
+// AddConversionFuncs registers conversion functions that convert between clientauthenticationv1beta1.ExecCredential and clientauthenticationv1.ExecCredential
+// by passing objects of those types to the provided function.
+func AddConversionFuncs(scheme *runtime.Scheme) error {
+	if err := scheme.AddConversionFunc(&clientauthenticationv1beta1.ExecCredential{}, &clientauthenticationv1.ExecCredential{}, func(a, b interface{}, scope conversion.Scope) error {
+		v1beta1ExecCredential, ok := a.(*clientauthenticationv1beta1.ExecCredential)
+		if !ok {
+			return errors.New("a is not a v1beta1 ExecCredential")
+		}
+
+		internalVersion := &clientauthentication.ExecCredential{}
+		err := clientauthenticationv1beta1.Convert_v1beta1_ExecCredential_To_clientauthentication_ExecCredential(v1beta1ExecCredential, internalVersion, scope)
+		if err != nil {
+			return err
+		}
+
+		return clientauthenticationv1.Convert_clientauthentication_ExecCredential_To_v1_ExecCredential(internalVersion, b.(*clientauthenticationv1.ExecCredential), scope)
+	}); err != nil {
+		return err
+	}
+
+	return scheme.AddConversionFunc(&clientauthenticationv1.ExecCredential{}, &clientauthenticationv1beta1.ExecCredential{}, func(a, b interface{}, scope conversion.Scope) error {
+		v1ExecCredential, ok := a.(*clientauthenticationv1.ExecCredential)
+		if !ok {
+			return errors.New("a is not a v1 ExecCredential")
+		}
+
+		internalVersion := &clientauthentication.ExecCredential{}
+		err := clientauthenticationv1.Convert_v1_ExecCredential_To_clientauthentication_ExecCredential(v1ExecCredential, internalVersion, scope)
+		if err != nil {
+			return err
+		}
+
+		return clientauthenticationv1beta1.Convert_clientauthentication_ExecCredential_To_v1beta1_ExecCredential(internalVersion, b.(*clientauthenticationv1beta1.ExecCredential), scope)
+	})
+}

--- a/internal/clientauthentication/conversion_test.go
+++ b/internal/clientauthentication/conversion_test.go
@@ -9,25 +9,11 @@ package clientauthentication_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/runtime"
 	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
 	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
-
-	"github.com/gardener/gardenlogin/internal/clientauthentication"
 )
 
 var _ = Describe("AddConversionFuncs", func() {
-	var scheme *runtime.Scheme
-
-	BeforeEach(func() {
-		scheme = runtime.NewScheme()
-
-		Expect(clientauthenticationv1beta1.AddToScheme(scheme)).To(Succeed())
-		Expect(clientauthenticationv1.AddToScheme(scheme)).To(Succeed())
-
-		Expect(clientauthentication.AddConversionFuncs(scheme)).To(Succeed())
-	})
-
 	It("should convert from v1beta1 to v1 ExecCredential type", func() {
 		// Create v1beta1 ExecCredential instance
 		v1beta1ExecCredential := &clientauthenticationv1beta1.ExecCredential{

--- a/internal/clientauthentication/conversion_test.go
+++ b/internal/clientauthentication/conversion_test.go
@@ -1,0 +1,74 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package clientauthentication_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
+	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
+
+	"github.com/gardener/gardenlogin/internal/clientauthentication"
+)
+
+var _ = Describe("AddConversionFuncs", func() {
+	var scheme *runtime.Scheme
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+
+		Expect(clientauthenticationv1beta1.AddToScheme(scheme)).To(Succeed())
+		Expect(clientauthenticationv1.AddToScheme(scheme)).To(Succeed())
+
+		Expect(clientauthentication.AddConversionFuncs(scheme)).To(Succeed())
+	})
+
+	It("should convert from v1beta1 to v1 ExecCredential type", func() {
+		// Create v1beta1 ExecCredential instance
+		v1beta1ExecCredential := &clientauthenticationv1beta1.ExecCredential{
+			Spec: clientauthenticationv1beta1.ExecCredentialSpec{
+				Cluster: &clientauthenticationv1beta1.Cluster{
+					Server: "https://kubernetes",
+				},
+			},
+		}
+
+		// Convert v1beta1 to v1 ExecCredential
+		obj, err := scheme.ConvertToVersion(v1beta1ExecCredential, clientauthenticationv1.SchemeGroupVersion)
+		Expect(err).NotTo(HaveOccurred())
+
+		v1ExecCredential, ok := obj.(*clientauthenticationv1.ExecCredential)
+		Expect(ok).To(BeTrue())
+
+		// Ensure that v1beta1 ExecCredential field match the original v1 instance.
+		// We do not test all fields, as we do not want to test the auto generated conversions
+		Expect(v1ExecCredential.Spec.Cluster.Server).To(Equal("https://kubernetes"))
+	})
+
+	It("should convert from v1 to v1beta1 ExecCredential type", func() {
+		// Create v1beta1 ExecCredential instance
+		v1ExecCredential := &clientauthenticationv1.ExecCredential{
+			Spec: clientauthenticationv1.ExecCredentialSpec{
+				Cluster: &clientauthenticationv1.Cluster{
+					Server: "https://kubernetes",
+				},
+			},
+		}
+
+		// Convert v1beta1 to v1 ExecCredential
+		obj, err := scheme.ConvertToVersion(v1ExecCredential, clientauthenticationv1beta1.SchemeGroupVersion)
+		Expect(err).NotTo(HaveOccurred())
+
+		v1beta1ExecCredential, ok := obj.(*clientauthenticationv1beta1.ExecCredential)
+		Expect(ok).To(BeTrue())
+
+		// Ensure that v1beta1 ExecCredential field match the original v1 instance.
+		// We do not test all fields, as we do not want to test the auto generated conversions
+		Expect(v1beta1ExecCredential.Spec.Cluster.Server).To(Equal("https://kubernetes"))
+	})
+})

--- a/main.go
+++ b/main.go
@@ -6,9 +6,21 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
+	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
+
 	"github.com/gardener/gardenlogin/cmd"
+	"github.com/gardener/gardenlogin/internal/clientauthentication"
 )
 
 func main() {
+	utilruntime.Must(clientauthenticationv1beta1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(clientauthenticationv1.AddToScheme(scheme.Scheme))
+
+	// we register our manual conversion between clientauthenticationv1beta1.ExecCredential and clientauthenticationv1.ExecCredential
+	utilruntime.Must(clientauthentication.AddConversionFuncs(scheme.Scheme))
+
 	cmd.Execute()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed issue when exec plugin in kubeconfig is configured to use API version `client.authentication.k8s.io/v1`:
```
users:
- name: garden-core--peter-test
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1
```
Previously the error `Error: failed to complete command options: cannot convert to ExecCredential: %!w(<nil>)` was returned.

With this PR `client.authentication.k8s.io/v1` is supported. Depending on the configured API version an `ExecCredential` with the same API version is returned. Currently supported versions:
- `client.authentication.k8s.io/v1`
- `client.authentication.k8s.io/v1beta1`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`client.authentication.k8s.io/v1` is now supported
```
