### PR TITLE
Bump golangci-lint to v1.52.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,5 +20,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1 # pin@v3.3.0
         with:
-          version: v1.50
+          version: v1.52.2
           args: --verbose --timeout 5m

--- a/cmd/get_client_certificate.go
+++ b/cmd/get_client_certificate.go
@@ -162,7 +162,7 @@ func NewCmdGetClientCertificate(f util.Factory, ioStreams util.IOStreams) *cobra
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *GetClientCertificateOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+func (o *GetClientCertificateOptions) Complete(f util.Factory, _ *cobra.Command, _ []string) error {
 	env := os.Getenv(execInfoEnv)
 	if env != "" { // KUBERNETES_EXEC_INFO env variable set for kubectl versions starting with v1.20.0
 		obj, _, err := exec.LoadExecCredential([]byte(env))

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -17,7 +17,7 @@ else
 fi
 
 # Install golangci-lint (linting tool)
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.2
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
 
 echo "> Lint gardenlogin"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps golangci-lint to v1.52.2

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
