### PR TITLE
Remove deprecated config property

### DIFF
--- a/internal/cmd/util/config.go
+++ b/internal/cmd/util/config.go
@@ -8,18 +8,12 @@ package util
 
 import (
 	"fmt"
-
-	"k8s.io/klog/v2"
 )
 
 // Config holds the gardenlogin config.
 type Config struct {
 	// Gardens is a list of known Garden clusters
 	Gardens []Garden `yaml:"gardens"`
-
-	// GardenClusters is a list of known Garden clusters
-	// Deprecated: use Gardens instead
-	GardenClusters []GardenClusterConfig `yaml:"gardenClusters"`
 }
 
 // Garden holds the config of a garden cluster.
@@ -36,37 +30,12 @@ type Garden struct {
 	Context string `yaml:"context"`
 }
 
-// GardenClusterConfig holds the config of a garden cluster.
-// Deprecated: use Garden instead.
-type GardenClusterConfig struct {
-	// ClusterIdentity is the cluster identifier of the garden cluster.
-	// Deprecated: use Garden.Identity instead.
-	ClusterIdentity string `yaml:"clusterIdentity"`
-
-	// Kubeconfig holds the path for the kubeconfig of the garden cluster.
-	// Deprecated: use Garden.Kubeconfig instead.
-	Kubeconfig string `yaml:"kubeconfig"`
-}
-
 // FindGarden returns the garden cluster config for a given cluster identity.
 // It returns an error if no matching garden cluster with the given cluster identity was found.
 func (c *Config) FindGarden(clusterIdentity string) (*Garden, error) {
 	for _, cluster := range c.Gardens {
 		if cluster.Identity == clusterIdentity {
 			return &cluster, nil
-		}
-	}
-
-	// fallback logic with deprecated properties
-	gardenClusters := c.GardenClusters
-	for _, cluster := range gardenClusters {
-		if cluster.ClusterIdentity == clusterIdentity {
-			klog.Warningln("Your are using deprecated config properties for gardenlogin. Please update your config file as these properties will not be supported in future versions. \"gardenClusters\" was renamed to \"gardens\", \"clusterIdentity\" was renamed to \"identity\".\n")
-
-			return &Garden{
-				Identity:   cluster.ClusterIdentity,
-				Kubeconfig: cluster.Kubeconfig,
-			}, nil
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the deprecated `gardenClusters` property. This property was deprecated since `v0.2.0`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The deprecated config properties (since `v0.2.0`, https://github.com/gardener/gardenlogin/pull/20) are not supported anymore. If not already done update your config file:
- `gardenClusters` was renamed to `gardens`
- `clusterIdentity` was renamed to `identity`
```
