### PR TITLE
Nix flake enablement for gardenlogin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ brew install gardener/tap/gardenlogin
 # Chocolatey (Windows)
 choco install gardenlogin
 ```
+### Install using Nix
+
+Nix with [Flakes](https://nixos.wiki/wiki/Flakes) (prerequisite: [Nix](https://nixos.org/download), the package manager):
+
+```bash
+# Nix (macOS, Linux, and Windows)
+
+# development version
+nix profile install github:gardener/gardenlogin
+# or release <version>
+nix profile install github:gardener/gardenlogin/<version>
+
+#check installation
+nix profile list | grep gardenlogin
+
+# optionally, open a new shell and verify that cmd completion works
+gardenlogin --help
+kubectl gardenlogin --help
+```
 
 ### Install from Github Release
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704420045,
+        "narHash": "sha256-C36QmoJd5tdQ5R9MC1jM7fBkZW9zBUqbUCsgwS6j4QU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c1be43e8e837b8dbee2b3665a007e761680f0c3d",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-23.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,101 @@
+{
+  description = "Nix flake for gardenlogin";
+
+  inputs = {
+    # NixPkgs (nixos-23.11)
+    nixpkgs.url = "nixpkgs/nixos-23.11"; #"github:NixOS/nixpkgs/nixos-23.11";
+  };
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      pname = "gardenlogin";
+
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in
+    {
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+          inherit (pkgs) stdenv lib;
+        in
+        {
+          ${pname} = pkgs.buildGo121Module rec {
+            inherit pname self;
+            version = lib.fileContents ./VERSION;
+            splitVersion = lib.versions.splitVersion version;
+            major = if ((lib.elemAt splitVersion 0) == "v") then lib.elemAt splitVersion 1 else lib.elemAt splitVersion 0;
+            minor = if ((lib.elemAt splitVersion 0) == "v") then lib.elemAt splitVersion 2 else lib.elemAt splitVersion 1;
+            gitCommit = if (self ? rev) then self.rev else self.dirtyRev;
+            state = if (self ? rev) then "clean" else "dirty";
+
+            # This vendorHash represents a dervative of all go.mod dependancies and needs to be adjusted with every change
+            vendorHash = "sha256-vmU0WrrEvfAHuWWrT9anZmQN+YNJIvrgjVUufws0X3s=";
+
+            src = ./.;
+
+            ldflags = [
+              "-s" "-w"
+              "-X k8s.io/component-base/version.gitMajor=${major}"
+              "-X k8s.io/component-base/version.gitMinor=${minor}"
+              "-X k8s.io/component-base/version.gitVersion=${version}"
+              "-X k8s.io/component-base/version.gitTreeState=${state}"
+              "-X k8s.io/component-base/version.gitCommit=${gitCommit}"
+              "-X k8s.io/component-base/version/verflag.programName=${pname}"
+            # "-X k8s.io/component-base/version.buildDate=1970-01-01T0:00:00+0000"
+            ];
+
+            CGO_ENABLED = 0;
+
+            # subPackages = [ 
+            # ];
+            nativeBuildInputs = [ pkgs.installShellFiles ];
+
+            postInstall = ''
+              ln -s $out/bin/${pname} $out/bin/kubectl-${pname}
+              installShellCompletion --cmd ${pname} --zsh  <($out/bin/${pname} completion zsh)
+              installShellCompletion --cmd ${pname} --bash <($out/bin/${pname} completion bash)
+              installShellCompletion --cmd ${pname} --fish <($out/bin/${pname} completion fish)
+            '';
+
+            meta = with lib; {
+              description = "gardenlogin is a kubectl credential plugin for Gardener";
+              longDescription = ''
+                gardenlogin is a kubectl credential plugin that facilitates Gardener managed cluster admin authentication.
+                It is used to generate kubeconfigs for clusters with short-lived certificates, to access the cluster as cluster-admin.
+              '';
+              homepage = "https://github.com/gardener/gardenlogin";
+              license = licenses.asl20;
+              platforms = supportedSystems;
+            };
+          };
+        });
+      
+      # Add dependencies that are only needed for development
+      devShells = forAllSystems (system:
+        let 
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [ 
+              go_1_21 
+              gopls 
+              gotools 
+              go-tools
+              gnumake
+            ];
+          };
+        });
+
+      # The default package for 'nix build'
+      defaultPackage = forAllSystems (system: self.packages.${system}.${pname});
+    };
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

We want to enable gardenlogin for the nix community.

```feature user
# with Nix (macOS, Linux, and Windows)

# development version
nix profile install github:gardener/gardenlogin

gardenlogin --help
kubectl gardenlogin --help
```
