### PR TITLE
Bump golang to 1.21.6

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,11 +9,11 @@ gardenlogin:
         inject_effective_version: true
     steps:
       check:
-        image: 'golang:1.20.2'
+        image: 'golang:1.21.6'
       test:
-        image: 'golang:1.20.2'
+        image: 'golang:1.21.6'
       build:
-        image: 'golang:1.20.2'
+        image: 'golang:1.21.6'
         output_dir: 'binary'
         timeout: '5m'
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # pin@v4.0.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
       - name: golangci-lint
         uses: golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1 # pin@v3.3.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,5 +20,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1 # pin@v3.3.0
         with:
-          version: v1.52.2
+          version: v1.55.2
           args: --verbose --timeout 5m

--- a/.github/workflows/update-gardenlogin.yaml
+++ b/.github/workflows/update-gardenlogin.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # pin@v3.5.0
         with:
-          go-version: '1.20.2'
+          go-version: '1.21.6'
       - name: Build the binary-files
         id: build_binary_files
         run: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,3 +21,11 @@ linters:
 linters-settings:
   goimports:
     local-prefixes: github.com/gardener/gardenlogin
+  revive:
+    rules:
+      - name: dot-imports
+        disabled: true # remove/enable once golangci-lint 1.55.3 is released where allowedPackages is supported
+        arguments:
+          - allowedPackages:
+              - "github.com/onsi/ginkgo/v2"
+              - "github.com/onsi/gomega"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardenlogin
 
-go 1.20
+go 1.21
 
 require (
 	github.com/gardener/gardener v1.67.1


### PR DESCRIPTION
**What this PR does / why we need it**:
- Bump golang to `1.21.6`
- Bump golangci-lint action to `v1.55.2`
- Temporarily disable `dot-import` revive lint rule

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
