### PR TITLE
Support `shoots/viewerkubeconfig`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@
 [![release](https://badge.fury.io/gh/gardener%2Fgardenlogin.svg)](https://badge.fury.io/gh/gardener%2Fgardenlogin)
 [![reuse compliant](https://reuse.software/badge/reuse-compliant.svg)](https://reuse.software/)
 
-`gardenlogin`s `get-client-certificate` command can be used as a `kubectl` [credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins). It fetches the `cluster-admin` credentials from the API introduced with [GEP-16](https://github.com/gardener/gardener/blob/master/docs/proposals/16-adminkubeconfig-subresource.md). See more details under [Authentication Flow](#authentication-flow)
+The `gardenlogin`s `get-client-certificate` command can be used as a `kubectl` [credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins). It supports fetching credentials from two subresources: [`shoots/adminkubeconfig`](https://github.com/gardener/gardener/blob/master/docs/proposals/16-adminkubeconfig-subresource.md) and `shoots/viewerkubeconfig`
 
-With GEP-16, users are able to generate kubeconfigs for `Shoot` clusters with short-lived certificates, to access the cluster as `cluster-admin`.
+By default, the plugin retrieves credentials from the `shoots/adminkubeconfig` subresource, granting full administrative access. Alternatively, it can fetch credentials from the `shoots/viewerkubeconfig` subresource for read-only access.
+
+The level of access for the fetched credentials can be controlled using the `--access-level` flag. This flag supports three options: `auto`, `admin`, and `viewer`. The default option is `auto`, which first attempts to fetch admin-level credentials and falls back to viewer-level credentials if the former is unsuccessful.
+
+For more information on how the plugin operates, refer to the [Authentication Flow](#authentication-flow) section.
 
 ## Installation
 

--- a/internal/certificatecache/store/store_test.go
+++ b/internal/certificatecache/store/store_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Store", func() {
 				ShootName:             "mycluster",
 				ShootNamespace:        "garden-myproject",
 				GardenClusterIdentity: "landscape-dev",
+				AccessLevel:           "viewer",
 			}
 			json := "{\"clientCertificateData\":\"Zm9v\",\"clientKeyData\":\"YmFy\"}"
 			filename, err := generateFilename(key)
@@ -60,6 +61,7 @@ var _ = Describe("Store", func() {
 				ShootName:             "mycluster",
 				ShootNamespace:        "garden-myproject",
 				GardenClusterIdentity: "landscape-dev",
+				AccessLevel:           "viewer",
 			}
 			certificateSet := certificatecache.CertificateSet{ClientCertificateData: []byte("foo"), ClientKeyData: []byte("bar")}
 			Expect(s.Save(key, certificateSet)).To(Succeed())

--- a/internal/certificatecache/types.go
+++ b/internal/certificatecache/types.go
@@ -17,6 +17,8 @@ type Key struct {
 	// GardenClusterIdentity is the cluster identity of the garden cluster.
 	// See cluster-identity ConfigMap in kube-system namespace of the garden cluster
 	GardenClusterIdentity string
+	// AccessLevel specifies the user access level for the requested credential
+	AccessLevel string
 }
 
 // CertificateSet represents a set of client certificate and client key.


### PR DESCRIPTION
**What this PR does / why we need it**:
Viewer credentials can now be requested using the flag `--access-level=viewer`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md#shootsviewerkubeconfig-subresource

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`get-client-certificate`: Viewer credentials can now be requested using the flag `--access-level=viewer`
```
