### PR TITLE
[hotfix-v0.5] Log `shoots/viewerkubeconfig` fallback with V-level `4`

### DIFF
--- a/cmd/get_client_certificate.go
+++ b/cmd/get_client_certificate.go
@@ -431,7 +431,7 @@ func (o *GetClientCertificateOptions) createKubeconfigRequest(ctx context.Contex
 		)
 
 		if apierrors.IsForbidden(err) {
-			logger.Info("No permission to obtain admin kubeconfig. Falling back to obtaining viewer kubeconfig.", "error", err)
+			logger.V(4).Info("No permission to obtain admin kubeconfig. Falling back to obtaining viewer kubeconfig.", "error", err)
 
 			kubeconfigRequest, err = createViewerKubeconfigRequest(
 				ctx,


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, as `viewer` with `access-level` flag set to `auto`, every time a new credential is fetched a log entry is written, which would annoy the user. 
```bash
k get configmap
I0208 15:14:58.553441   10796 get_client_certificate.go:434] "No permission to obtain admin kubeconfig. Falling back to obtaining viewer kubeconfig." error="shoots.core.gardener.cloud \"myshoot\" is forbidden: User \"system:serviceaccount:garden-myproject:robot\" cannot create resource \"shoots/adminkubeconfig\" in API group \"core.gardener.cloud\" in the namespace \"garden-myproject\""
NAME               DATA   AGE
kube-root-ca.crt   1      7d4h
```

With this PR, you have to set `--v=4` or higher to see the fallback log entry.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The log entry when falling back to `shoots/viewerkubeconfig` is now only shown when using verbosity level 4 (`--v=4`) or higher
```
