### PR TITLE
prepended sudo to gardenlogin symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ chmod +x "./gardenlogin_${os}_${arch}"
 sudo mv "./gardenlogin_${os}_${arch}" /usr/local/bin/gardenlogin
 
 # create kubectl-gardenlogin symlink
-ln -s /usr/local/bin/gardenlogin /usr/local/bin/kubectl-gardenlogin
+sudo ln -s /usr/local/bin/gardenlogin /usr/local/bin/kubectl-gardenlogin
 ```
 
 ## Configure Gardenlogin


### PR DESCRIPTION
**What this PR does / why we need it**:
`sudo` is needed for symlink to create `/usr/local/bin/kubectl-gardenlogin`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Fix for install doc on linux
```
