### PR TITLE
Add ocm repository mappings

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,6 +9,9 @@ gardenlogin:
         inject_effective_version: true
       component_descriptor:
         ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
+        ocm_repository_mappings:
+        - repository: europe-docker.pkg.dev/gardener-project/releases
+          prefix: ''
     steps:
       check:
         image: 'golang:1.23.2'


### PR DESCRIPTION
**What this PR does / why we need it**:
Configure the europe-docker.pkg.dev/gardener-project/releases OCM repository as lookup, so that the head-update job (which only knows the .../snapshots repository by now), also detects the release version in .../releases repository

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
