### PR TITLE
chore: Disable binary upload

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -48,6 +48,7 @@ gardenlogin:
             artefact_extra_id:
               os: linux
               architecture: amd64
+            upload_as_github_asset: false
           - type: build-step-file
             mode: single-file
             step_name: build
@@ -58,6 +59,7 @@ gardenlogin:
             artefact_extra_id:
               os: linux
               architecture: arm64
+            upload_as_github_asset: false
           - type: build-step-file
             mode: single-file
             step_name: build
@@ -68,6 +70,7 @@ gardenlogin:
             artefact_extra_id:
               os: darwin
               architecture: amd64
+            upload_as_github_asset: false
           - type: build-step-file
             mode: single-file
             step_name: build
@@ -78,6 +81,7 @@ gardenlogin:
             artefact_extra_id:
               os: darwin
               architecture: arm64
+            upload_as_github_asset: false
           - type: build-step-file
             mode: single-file
             step_name: build
@@ -88,6 +92,7 @@ gardenlogin:
             artefact_extra_id:
               os: windows
               architecture: amd64
+            upload_as_github_asset: false
           - type: build-step-log
             step_name: verify
             purposes:


### PR DESCRIPTION
**What this PR does / why we need it**:
We should transition to reusing the binaries generated by the CI pipeline instead of building them separately in the Action (or vice versa, as described in https://github.com/gardener/gardenlogin/issues/182). Currently, we have disabled the binary upload from the CI pipeline, but this should be re-enabled once we implement the proper reuse strategy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
https://github.com/gardener/cc-utils/pull/1120

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
