### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -2,6 +2,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/gardenlogin/security/code-scanning/1](https://github.com/gardener/gardenlogin/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the required permissions. Since the workflow only performs a compliance check, it likely only needs `contents: read` permission. This will ensure the workflow adheres to the principle of least privilege and avoids unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
