### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-gardenlogin.yaml
+++ b/.github/workflows/update-gardenlogin.yaml
@@ -1,5 +1,10 @@
 name: gardenlogin-updater
 
+permissions:
+  contents: write
+  actions: read
+  repository-projects: write
+
 on:
   release:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/gardenlogin/security/code-scanning/2](https://github.com/gardener/gardenlogin/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions and steps in the workflow, the following permissions are required:
- `contents: read` for accessing repository contents.
- `contents: write` for uploading release assets.
- `actions: read` for interacting with GitHub Actions.
- `repository-projects: write` for dispatching events to other repositories.

The `permissions` block will be added at the root level, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
