### PR TITLE
use `ubuntu-latest` as runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
         run: exit 1
 
   verify-others:
-    runs-on: ubuntu
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     env:


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes hanging job run as "ubuntu" (without a version qualifier) is not a recognized label for GitHub-hosted runners. When an invalid label is used, GitHub Actions queues the job but can't assign it to a runner, leading to it hanging with a "Waiting for a runner to pick up this job" status (or similar) under the hood, though no logs appear until a runner starts

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
