### PR TITLE
Use golangci-lint `wsl_v5`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,8 +13,12 @@ linters:
     - unconvert
     - wastedassign
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
     revive:
       rules:
         - name: dot-imports


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the following warning by using golangci-lint `wsl_v5`:
```bash
WARN The linter "wsl" is deprecated (since v2.2.0) due to: new major version. Replaced by wsl_v5.
WARN [linter] `allow-multiline-assign` is deprecated and always allowed in wsl >= v5
WARN Suggested new configuration:
linters:
  enable:
    - wsl_v5
  settings:
    wsl_v5:
      allow-first-in-block: true
      allow-whole-block: false
      branch-max-lines: 2
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
