### PR TITLE
fix missing .exe suffix for windows build asset

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
           LD_FLAGS="$(hack/get-build-ld-flags.sh)" \
           GOOS=${{ matrix.args.os }} \
           GOARCH=${{ matrix.args.arch }} \
-          out_file="/tmp/blobs.d/gardenlogin-${{ matrix.args.os}}-${{ matrix.args.arch }}" \
+          out_file="/tmp/blobs.d/gardenlogin-${{ matrix.args.os }}-${{ matrix.args.arch }}${{ matrix.args.os == 'windows' && '.exe' || '' }}" \
             hack/build.sh
       - uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
         with:
@@ -79,7 +79,7 @@ jobs:
             access:
               type: localBlob
               localReference: >-
-                gardenlogin-${{ matrix.args.os }}-${{ matrix.args.arch }}
+                gardenlogin-${{ matrix.args.os }}-${{ matrix.args.arch }}${{ matrix.args.os == 'windows' && '.exe' || '' }}
 
   build-gardenlogin-summary:
     name: Build Summary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
             name: gardenlogin
             os: linux
             architecture: arm64
-        - name: gardenlogin_windows_amd64
+        - name: gardenlogin_windows_amd64.exe
           type: ocm-resource
           id:
             name: gardenlogin


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix missing `.exe` suffix for windows build asset

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
