### PR TITLE
Add workflow to prepare hotfix branch

### DIFF
--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -1,0 +1,20 @@
+name: Prepare Hotfix Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag for which the hotfix should be created'
+        required: true
+        type: string
+
+jobs:
+  call-dashboard-workflow:
+    uses: gardener/dashboard/.github/workflows/prepare-hotfix-branch.yaml@master
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      tag: ${{ inputs.tag }}
+    secrets:
+      GARDENER_GITHUB_ACTIONS_PRIVATE_KEY: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a workflow to prepare hotfix a branch. The workflow will create a PR for applying the changes to the newly created hotfix branch. The workflow accepts the tag, for which a hotfix branch should be created.
The dashboard workflow is being reused ([ref](https://github.com/gardener/dashboard/pull/2578)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
