### PR TITLE
GithubAction: Reuse cherry-pick action

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: none  # we rely on the GitHub App token instead
+
 jobs:
   cherry-pick:
     if: |

--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -1,0 +1,19 @@
+name: Cherry Pick Action
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  cherry-pick:
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/cherry-pick ') &&
+      (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER') &&
+      github.event.comment.user.type == 'User'
+    uses: gardener/dashboard/.github/workflows/cherry-pick-reusable.yaml@master
+    with:
+      pr-number: ${{ github.event.issue.number }}
+      comment-body: ${{ github.event.comment.body }}
+    secrets:
+      GARDENER_GITHUB_ACTIONS_PRIVATE_KEY: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, the cherry-pick action(s) from the gardener/dashboard repository are reused. Only the cherry-pick workflow file needs to be duplicated

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
