### PR TITLE
No permissions needed for github token

### DIFF
--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -8,12 +8,12 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: none  # we rely on the GitHub App token instead
+
 jobs:
   call-dashboard-workflow:
     uses: gardener/dashboard/.github/workflows/prepare-hotfix-branch.yaml@master
-    permissions:
-      contents: write
-      pull-requests: write
     with:
       tag: ${{ inputs.tag }}
     secrets:


### PR DESCRIPTION
**What this PR does / why we need it**:
Set 
```
permissions:
  contents: none 
```
on workflow level as we rely on the github app token

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
related PR: https://github.com/gardener/dashboard/pull/2582

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
