### PR TITLE
ci: consistently use 5m timeout for linter

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,7 +102,7 @@ jobs:
     env:
       GO_TEST_RACE: 1
       GOLANGCI_LINT_VERBOSE: 1
-      GOLANGCI_LINT_TIMEOUT: 2m
+      GOLANGCI_LINT_TIMEOUT: 5m
     strategy:
       fail-fast: false
       matrix:

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -15,19 +15,21 @@ export SOURCE_PATH="$(readlink -f "$SOURCE_PATH")"
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION=v2.4.0
 
-GOLANGCI_LINT_TIMEOUT="${GOLANGCI_LINT_TIMEOUT:-1m}"
+GOLANGCI_LINT_TIMEOUT="${GOLANGCI_LINT_TIMEOUT:-5m}"
 GOLANGCI_LINT_VERBOSE="${GOLANGCI_LINT_VERBOSE:-0}"
 
 # Install golangci-lint if not present or version mismatch
 if ! which golangci-lint >/dev/null 2>&1 || ! golangci-lint --version | grep -q "version ${GOLANGCI_LINT_VERSION#v}"; then
-  echo "Downloading golangci-lint..."
+  echo "> Downloading golangci-lint..."
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
 fi
 
 VERBOSE_FLAG=""
 if [ "${GOLANGCI_LINT_VERBOSE}" = "1" ]; then
   VERBOSE_FLAG="--verbose"
+  echo "> Enabling verbose output for golangci-lint"
 fi
+echo "> Timeout for golangci-lint set to ${GOLANGCI_LINT_TIMEOUT}"
 
 echo "> Running golangci-lint for $SOURCE_PATH"
 pushd "$SOURCE_PATH" > /dev/null


### PR DESCRIPTION
**What this PR does / why we need it**:
consistently use 5m timeout for linter

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
