### PR TITLE
Recommend installation using winget on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ For more information on how the plugin operates, refer to the [Authentication Fl
 
 ## Installation
 
-Install the latest release from [Homebrew](https://brew.sh/), [Chocolatey](https://chocolatey.org/packages/gardenlogin) or [GitHub Releases](https://github.com/gardener/gardenlogin/releases).
+Install the latest release from [Homebrew](https://brew.sh/), [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/), [Chocolatey](https://chocolatey.org/packages/gardenlogin) or [GitHub Releases](https://github.com/gardener/gardenlogin/releases).
 
 ### Install using Package Managers
 
 ```sh
 # Homebrew (macOS and Linux)
 brew install gardener/tap/gardenlogin
+
+# winget (Windows)
+winget install -e --id Gardener.gardenlogin
 
 # Chocolatey (Windows)
 choco install gardenlogin


### PR DESCRIPTION
**What this PR does / why we need it**:
With winget being included by default in Windows 11 and Windows Server 2025, it no longer seems like a good idea to promote an installation using chocolatey on Windows.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
See also: gardener/gardenctl-v2#726

**Release note**:
```doc user
Describe installation using winget instead of chocolatey
```
