### PR TITLE
Update copyright text

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ci/build
+++ b/.ci/build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ci/update_latest_version
+++ b/.ci/update_latest_version
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ci/update_latest_version
+++ b/.ci/update_latest_version
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ci/verify
+++ b/.ci/verify
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ci/verify
+++ b/.ci/verify
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -21,11 +21,11 @@ path = [
   "VERSION"
 ]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
+SPDX-FileCopyrightText = "Contributors to the Gardener project"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["**.md"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
+SPDX-FileCopyrightText = "Contributors to the Gardener project"
 SPDX-License-Identifier = "CC-BY-4.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -21,11 +21,11 @@ path = [
   "VERSION"
 ]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2021-2024 SAP SE or an SAP affiliate company and Gardener contributors"
+SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ["**.md"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2021-2024 SAP SE or an SAP affiliate company and Gardener contributors"
+SPDX-FileCopyrightText = "Copyright Contributors to the Gardener project"
 SPDX-License-Identifier = "CC-BY-4.0"

--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/cmd/cmd_suite_test.go
+++ b/cmd/cmd_suite_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/cmd/get_client_certificate.go
+++ b/cmd/get_client_certificate.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/cmd/get_client_certificate.go
+++ b/cmd/get_client_certificate.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/cmd/get_client_certificate_test.go
+++ b/cmd/get_client_certificate_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/cmd/get_client_certificate_test.go
+++ b/cmd/get_client_certificate_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/example/01-kubeconfig-legacy.yaml
+++ b/example/01-kubeconfig-legacy.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/example/01-kubeconfig-legacy.yaml
+++ b/example/01-kubeconfig-legacy.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/example/01-kubeconfig.yaml
+++ b/example/01-kubeconfig.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/example/01-kubeconfig.yaml
+++ b/example/01-kubeconfig.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/hack/build-darwin-amd64.sh
+++ b/hack/build-darwin-amd64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build-darwin-amd64.sh
+++ b/hack/build-darwin-amd64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build-darwin-arm64.sh
+++ b/hack/build-darwin-arm64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build-darwin-arm64.sh
+++ b/hack/build-darwin-arm64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build-linux-amd64.sh
+++ b/hack/build-linux-amd64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build-linux-amd64.sh
+++ b/hack/build-linux-amd64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build-linux-arm64.sh
+++ b/hack/build-linux-arm64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build-linux-arm64.sh
+++ b/hack/build-linux-arm64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build-windows-amd64.sh
+++ b/hack/build-windows-amd64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build-windows-amd64.sh
+++ b/hack/build-windows-amd64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/check-generate.sh
+++ b/hack/check-generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/check-generate.sh
+++ b/hack/check-generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/tools/install-gosec.sh
+++ b/hack/tools/install-gosec.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+# SPDX-FileCopyrightText: Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hack/tools/install-gosec.sh
+++ b/hack/tools/install-gosec.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/internal/certificatecache/store/store.go
+++ b/internal/certificatecache/store/store.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/certificatecache/store/store.go
+++ b/internal/certificatecache/store/store.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/certificatecache/store/store_suite_test.go
+++ b/internal/certificatecache/store/store_suite_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/certificatecache/store/store_suite_test.go
+++ b/internal/certificatecache/store/store_suite_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/certificatecache/store/store_test.go
+++ b/internal/certificatecache/store/store_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/certificatecache/store/store_test.go
+++ b/internal/certificatecache/store/store_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/certificatecache/types.go
+++ b/internal/certificatecache/types.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/certificatecache/types.go
+++ b/internal/certificatecache/types.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/clientauthentication/clientauthentication_suite_test.go
+++ b/internal/clientauthentication/clientauthentication_suite_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/clientauthentication/clientauthentication_suite_test.go
+++ b/internal/clientauthentication/clientauthentication_suite_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/clientauthentication/conversion.go
+++ b/internal/clientauthentication/conversion.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/clientauthentication/conversion.go
+++ b/internal/clientauthentication/conversion.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/clientauthentication/conversion_test.go
+++ b/internal/clientauthentication/conversion_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/clientauthentication/conversion_test.go
+++ b/internal/clientauthentication/conversion_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/cmd/util/clock.go
+++ b/internal/cmd/util/clock.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/cmd/util/clock.go
+++ b/internal/cmd/util/clock.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/cmd/util/config.go
+++ b/internal/cmd/util/config.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/cmd/util/config.go
+++ b/internal/cmd/util/config.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/cmd/util/factory.go
+++ b/internal/cmd/util/factory.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/cmd/util/factory.go
+++ b/internal/cmd/util/factory.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/cmd/util/io_streams.go
+++ b/internal/cmd/util/io_streams.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/internal/cmd/util/io_streams.go
+++ b/internal/cmd/util/io_streams.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: Copyright Contributors to the Gardener project
+SPDX-FileCopyrightText: Contributors to the Gardener project
 
 SPDX-License-Identifier: Apache-2.0
 */


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the SPDX copyright text from `SAP SE or an SAP affiliate company and Gardener contributors` to `Contributors to the Gardener project` across all files.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated copyright and SPDX attribution notices throughout the project to use current Gardener project contributor wording.
  - Removed outdated year-specific, company-specific, and redundant “Copyright” references.

- **Chores**
  - Standardized attribution across build, verification, tooling, source, test, and example files.
  - Build scripts, verification processes, command behavior, and application functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->